### PR TITLE
Make executor interface make copies of the supplied executors.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_ARG_WITH(boost,
     CPPFLAGS="$CPPFLAGS -DEXECUTORS_NO_BOOST=1"
   else
     CPPFLAGS="$CPPFLAGS -I${withval}"
-    LIBS="$LIBS -L${withval}/stage/lib -lboost_coroutine -lboost_context -lboost_system"
+    LIBS="$LIBS -L${withval}/stage/lib -lboost_coroutine -lboost_thread -lboost_context -lboost_system"
   fi
 ],
 [

--- a/include/experimental/bits/codefer.h
+++ b/include/experimental/bits/codefer.h
@@ -39,7 +39,7 @@ inline typename __coinvoke_without_executor<_CompletionTokens...>::_Result
 template <class _Executor>
 struct __coinvoke_defer_ex
 {
-  typename remove_reference<_Executor>::type& __e;
+  typename remove_reference<_Executor>::type __e;
 
   template <class _E, class _F, class _A>
   void operator()(_E&, _F&& __f, const _A& __a)

--- a/include/experimental/bits/codispatch.h
+++ b/include/experimental/bits/codispatch.h
@@ -39,7 +39,7 @@ inline typename __coinvoke_without_executor<_CompletionTokens...>::_Result
 template <class _Executor>
 struct __coinvoke_dispatch_ex
 {
-  typename remove_reference<_Executor>::type& __e;
+  typename remove_reference<_Executor>::type __e;
 
   template <class _E, class _F, class _A>
   void operator()(_E&, _F&& __f, const _A& __a)

--- a/include/experimental/bits/copost.h
+++ b/include/experimental/bits/copost.h
@@ -39,7 +39,7 @@ inline typename __coinvoke_without_executor<_CompletionTokens...>::_Result
 template <class _Executor>
 struct __coinvoke_post_ex
 {
-  typename remove_reference<_Executor>::type& __e;
+  typename remove_reference<_Executor>::type __e;
 
   template <class _E, class _F, class _A>
   void operator()(_E&, _F&& __f, const _A& __a)


### PR DESCRIPTION
The copost, codefer and codispatch functions taking Executors fail to compile.  This issue is that the code tries to bind a const ref to non-const ref here;

``` c++
typename remove_reference<_Executor>::type& __e; // Non-const-ref
```

But the functions all take a const-ref Executor;

``` c++
codefer(const _Executor& __e,
```

and try to bind it;

``` c++
__coinvoke_defer_ex<_Executor>{__e} // __e is a const-ref, error.
```

I fixed this by making a copy of the executor because it looks like they're supposed to be lightwheight.  I also see that that is what other functions in the library have done.  For example, dispatch does this;

``` c++
_Executor __completion_executor(__e); // Make a copy.
```

As a side, I added dependency on Boost.Thread to fix undefined reference to `boost::thread_detail::commit_once_region(boost::once_flag&)'
