### PR TITLE
Fully qualify calls to std::forward to avoid ADL injection.

### DIFF
--- a/include/experimental/bits/await_context.h
+++ b/include/experimental/bits/await_context.h
@@ -182,8 +182,8 @@ class __await_context_impl
 public:
   template <class _F, class _C, class... _A>
   __await_context_impl(const executor_work<_Executor>& __w, _F&& __f, _C&& __c, _A&&... __args)
-    : _M_work(__w), _M_function(forward<_F>(__f)), _M_invocations(0),
-      _M_continuation(forward<_C>(__c)), _M_args(forward<_A>(__args)...)
+    : _M_work(__w), _M_function(std::forward<_F>(__f)), _M_invocations(0),
+      _M_continuation(std::forward<_C>(__c)), _M_args(std::forward<_A>(__args)...)
   {
   }
 
@@ -242,7 +242,7 @@ struct __await_context_result
   template <class... _Args>
   static void _Set_value(void* __r, _Args&&... __args)
   {
-    *static_cast<_Type*>(__r) = _Tuple_get(std::make_tuple(forward<_Args>(__args)...));
+    *static_cast<_Type*>(__r) = _Tuple_get(std::make_tuple(std::forward<_Args>(__args)...));
   }
 };
 
@@ -274,7 +274,7 @@ struct __await_context_handler
 
   template <class... _Args> void operator()(_Args&&... __args)
   {
-    _Result::_Set_value(_M_impl->_M_result_value, forward<_Args>(__args)...);
+    _Result::_Set_value(_M_impl->_M_result_value, std::forward<_Args>(__args)...);
     _M_impl->_Resume();
   }
 
@@ -304,7 +304,7 @@ struct __await_context_handler<_Executor, error_code, _Values...>
       *_M_impl->_M_result_ec = __e;
     else if (__e)
       _M_impl->_M_ex = make_exception_ptr(system_error(__e));
-    _Result::_Set_value(_M_impl->_M_result_value, forward<_Args>(__args)...);
+    _Result::_Set_value(_M_impl->_M_result_value, std::forward<_Args>(__args)...);
     _M_impl->_Resume();
   }
 
@@ -332,7 +332,7 @@ struct __await_context_handler<_Executor, exception_ptr, _Values...>
   {
     if (__e)
       _M_impl->_M_ex = make_exception_ptr(__e);
-    _Result::_Set_value(_M_impl->_M_result_value, forward<_Args>(__args)...);
+    _Result::_Set_value(_M_impl->_M_result_value, std::forward<_Args>(__args)...);
     _M_impl->_Resume();
   }
 
@@ -382,19 +382,19 @@ struct __await_context_launcher
   _Continuation _M_continuation;
 
   template <class _F> __await_context_launcher(_F&& __f)
-    : _M_work(associated_executor<_Func>::get(__f)), _M_func(forward<_F>(__f))
+    : _M_work(associated_executor<_Func>::get(__f)), _M_func(std::forward<_F>(__f))
   {
   }
 
   template <class _F> __await_context_launcher(
     executor_arg_t, const _Executor& __e, _F&& __f)
-      : _M_work(__e), _M_func(forward<_F>(__f))
+      : _M_work(__e), _M_func(std::forward<_F>(__f))
   {
   }
 
   template <class _F, class _C> __await_context_launcher(
     true_type, const executor_work<_Executor>& __w, _F&& __f, _C&& __c)
-      : _M_work(__w), _M_func(forward<_F>(__f)), _M_continuation(forward<_C>(__c))
+      : _M_work(__w), _M_func(std::forward<_F>(__f)), _M_continuation(std::forward<_C>(__c))
   {
   }
 
@@ -407,7 +407,7 @@ struct __await_context_launcher
   {
     auto __impl = make_shared<__await_context_impl<
       _Executor, _Func, _Continuation, typename decay<_Args>::type...>>(_M_work,
-        std::move(_M_func), std::move(_M_continuation), forward<_Args>(__args)...);
+        std::move(_M_func), std::move(_M_continuation), std::forward<_Args>(__args)...);
     __impl->_Resume();
   }
 };
@@ -447,7 +447,7 @@ struct continuation_of<__await_context_launcher<_Executor, _Func>(_Args...)>
   {
     return __await_context_launcher<_Executor, _Func,
       typename decay<_Continuation>::type>(true_type(), std::move(__f._M_work),
-        std::move(__f._M_func), forward<_Continuation>(__c));
+        std::move(__f._M_func), std::forward<_Continuation>(__c));
   }
 };
 

--- a/include/experimental/bits/channel.h
+++ b/include/experimental/bits/channel.h
@@ -34,7 +34,7 @@ public:
 
   template <class _U> void _Set_value(_U&& __u)
   {
-    new (&_M_value) value_type(forward<_U>(__u));
+    new (&_M_value) value_type(std::forward<_U>(__u));
     _M_has_value = true;
   }
 
@@ -44,7 +44,7 @@ protected:
   template <class _U>
   _Op(_U&& __u)
   {
-    this->_Set_value(forward<_U>(__u));
+    this->_Set_value(std::forward<_U>(__u));
   }
 
   ~_Op()
@@ -66,7 +66,7 @@ class channel<_T, _Cont>::_PutOp
 {
 public:
   template <class _U, class _H> explicit _PutOp(_U&& __u, _H&& __h)
-    : _Op(forward<_U>(__u)), _M_handler(forward<_H>(__h)),
+    : _Op(std::forward<_U>(__u)), _M_handler(std::forward<_H>(__h)),
       _M_work(get_associated_executor(_M_handler))
   {
   }
@@ -107,7 +107,7 @@ class channel<_T, _Cont>::_GetOp
 {
 public:
   template <class _H> explicit _GetOp(_H&& __h)
-    : _M_handler(forward<_H>(__h)), _M_work(get_associated_executor(_M_handler))
+    : _M_handler(std::forward<_H>(__h)), _M_work(get_associated_executor(_M_handler))
   {
   }
 
@@ -231,7 +231,7 @@ template <class _T, class _Cont> template <class _U>
 void channel<_T, _Cont>::put(_U&& __u)
 {
   error_code __ec;
-  this->put(forward<_U>(__u), __ec);
+  this->put(std::forward<_U>(__u), __ec);
   if (__ec)
     throw system_error(__ec);
 }
@@ -248,7 +248,7 @@ void channel<_T, _Cont>::put(_U&& __u, error_code& __ec)
     }
   case __channel_state::buffer:
     {
-      _M_buffer.push_back(forward<_U>(__u));
+      _M_buffer.push_back(std::forward<_U>(__u));
       _M_get_state = __channel_state::buffer;
       if (_M_buffer.size() == _Capacity())
         _M_put_state = __channel_state::block;
@@ -258,7 +258,7 @@ void channel<_T, _Cont>::put(_U&& __u, error_code& __ec)
   case __channel_state::waiter:
     {
       _Op* __getter = static_cast<_Op*>(_M_waiters._Front());
-      __getter->_Set_value(forward<_U>(__u));
+      __getter->_Set_value(std::forward<_U>(__u));
       _M_waiters._Pop();
       if (_M_waiters._Empty())
         _M_put_state = _Capacity() ? __channel_state::buffer : __channel_state::block;
@@ -283,7 +283,7 @@ auto channel<_T, _Cont>::put(_U&& __u, _CompletionToken&& __token)
 
   auto __allocator(get_associated_allocator(__completion.handler));
   auto __op(_Allocate_small_block<_PutOp<_Handler>>(__allocator,
-    forward<_U>(__u), std::move(__completion.handler)));
+    std::forward<_U>(__u), std::move(__completion.handler)));
 
   _Start_put(__op.get());
   __op.release();

--- a/include/experimental/bits/channel_void.h
+++ b/include/experimental/bits/channel_void.h
@@ -29,7 +29,7 @@ public:
   typedef executor_work<_Executor> _Work;
 
   template <class _H> explicit _Op(_H&& __h)
-    : _M_handler(forward<_H>(__h)),
+    : _M_handler(std::forward<_H>(__h)),
       _M_work(get_associated_executor(_M_handler))
   {
   }

--- a/include/experimental/bits/codefer.h
+++ b/include/experimental/bits/codefer.h
@@ -23,7 +23,7 @@ struct __coinvoke_defer
   template <class _E, class _F, class _A>
   void operator()(_E& __e, _F&& __f, const _A& __a)
   {
-    __e.defer(forward<_F>(__f), __a);
+    __e.defer(std::forward<_F>(__f), __a);
   }
 };
 
@@ -45,7 +45,7 @@ struct __coinvoke_defer_ex
   template <class _E, class _F, class _A>
   void operator()(_E&, _F&& __f, const _A& __a)
   {
-    __e.defer(forward<_F>(__f), __a);
+    __e.defer(std::forward<_F>(__f), __a);
   }
 };
 

--- a/include/experimental/bits/codispatch.h
+++ b/include/experimental/bits/codispatch.h
@@ -23,7 +23,7 @@ struct __coinvoke_dispatch
   template <class _E, class _F, class _A>
   void operator()(_E& __e, _F&& __f, const _A& __a)
   {
-    __e.dispatch(forward<_F>(__f), __a);
+    __e.dispatch(std::forward<_F>(__f), __a);
   }
 };
 
@@ -45,7 +45,7 @@ struct __coinvoke_dispatch_ex
   template <class _E, class _F, class _A>
   void operator()(_E&, _F&& __f, const _A& __a)
   {
-    __e.dispatch(forward<_F>(__f), __a);
+    __e.dispatch(std::forward<_F>(__f), __a);
   }
 };
 

--- a/include/experimental/bits/coinvoker.h
+++ b/include/experimental/bits/coinvoker.h
@@ -49,7 +49,7 @@ public:
   template <class... _Args> void _Set_value(_Args&&... __args)
   {
     assert(!_M_has_value);
-    new (&_M_value) _Result(forward<_Args>(__args)...);
+    new (&_M_value) _Result(std::forward<_Args>(__args)...);
     _M_has_value = true;
   }
 
@@ -95,7 +95,7 @@ public:
 
   template <size_t _Index, class... _Args> void _Set_result(_Args&&... __args)
   {
-    get<_Index>(_M_results)._Set_value(forward<_Args>(__args)...);
+    get<_Index>(_M_results)._Set_value(std::forward<_Args>(__args)...);
   }
 
   void _Complete()
@@ -162,7 +162,7 @@ public:
 
   template <class... _Args> void operator()(_Args&&... __args)
   {
-    _M_tail->template _Set_result<_Index>(forward<_Args>(__args)...);
+    _M_tail->template _Set_result<_Index>(std::forward<_Args>(__args)...);
     auto* __t = _M_tail;
     _M_tail = 0;
     __t->_Complete();
@@ -260,7 +260,7 @@ private:
   {
     _M_tail->_Prime();
     _M_tail.release();
-    (_Go_2)(__a, forward<_Invokers>(__i)...);
+    (_Go_2)(__a, std::forward<_Invokers>(__i)...);
   }
 
   template <class _Action> static void _Go_2(_Action&) {}
@@ -271,7 +271,7 @@ private:
     auto __executor(__i._Get_executor());
     auto __allocator(__i._Get_allocator());
     __a(__executor, std::move(__i), __allocator);
-    (_Go_2)(__a, forward<_Invokers>(__j)...);
+    (_Go_2)(__a, std::forward<_Invokers>(__j)...);
   }
 
   unique_ptr<__coinvoker_tail<tuple<_HeadTokens...>, tuple<_TailToken>>> _M_tail;

--- a/include/experimental/bits/continuation.h
+++ b/include/experimental/bits/continuation.h
@@ -71,13 +71,13 @@ public:
     "continuation's continuation must accept specified return value");
 
   template <class _T> explicit __continuation_impl(_T&& __t)
-    : _M_continuation(forward<_T>(__t)), _M_executor(associated_executor<_Continuation>::get(_M_continuation))
+    : _M_continuation(std::forward<_T>(__t)), _M_executor(associated_executor<_Continuation>::get(_M_continuation))
   {
   }
 
   virtual void _Call(_Args... __args)
   {
-    std::move(_M_continuation)(forward<_Args>(__args)...);
+    std::move(_M_continuation)(std::forward<_Args>(__args)...);
   }
 
   virtual void _Call_with_continuation(_Args... __args,
@@ -85,7 +85,7 @@ public:
   {
     continuation_of<_Continuation(_Args...)>::chain(
       std::move(_M_continuation), std::move(__c))(
-        forward<_Args>(__args)...);
+        std::forward<_Args>(__args)...);
   }
 
   virtual const type_info& _Target_type()
@@ -201,7 +201,7 @@ inline void continuation<_R(_Args...)>::operator()(_Args... __args)
 {
   if (!_M_impl)
     throw bad_continuation();
-  _M_impl->_Call(forward<_Args>(__args)...);
+  _M_impl->_Call(std::forward<_Args>(__args)...);
 }
 
 template <class _R, class... _Args>
@@ -230,7 +230,7 @@ struct __continuation_chain
 
   void operator()(_Args... __args)
   {
-    _M_head._M_impl->_Call_with_continuation(forward<_Args>(__args)..., std::move(_M_tail));
+    _M_head._M_impl->_Call_with_continuation(std::forward<_Args>(__args)..., std::move(_M_tail));
   }
 };
 
@@ -242,7 +242,7 @@ struct continuation_of<continuation<_R(_Args...)>(_Args2...)>
   template <class _C>
   static auto chain(continuation<_R(_Args...)>&& __f, _C&& __c)
   {
-    return __continuation_chain<_R, _Args...>{std::move(__f), forward<_C>(__c)};
+    return __continuation_chain<_R, _Args...>{std::move(__f), std::forward<_C>(__c)};
   }
 };
 
@@ -437,18 +437,18 @@ struct __continuation_launcher
   continuation<_Signature> _M_continuation;
 
   template <class _F> explicit __continuation_launcher(_F&& __f)
-    : _M_func(forward<_F>(__f))
+    : _M_func(std::forward<_F>(__f))
   {
   }
 
   template <class _F, class _C> __continuation_launcher(_F&& __f, _C&& __c)
-    : _M_func(forward<_F>(__f)), _M_continuation(forward<_C>(__c))
+    : _M_func(std::forward<_F>(__f)), _M_continuation(std::forward<_C>(__c))
   {
   }
 
   template <class... _Args> void operator()(_Args&&... __args)
   {
-    std::move(_M_func)(forward<_Args>(__args)..., std::move(_M_continuation));
+    std::move(_M_func)(std::forward<_Args>(__args)..., std::move(_M_continuation));
   }
 };
 
@@ -461,7 +461,7 @@ struct continuation_of<__continuation_launcher<_Func, _Signature>(_Args...)>
   static auto chain(__continuation_launcher<_Func, _Signature>&& __f, _Continuation&& __c)
   {
     return __continuation_launcher<_Func, _Signature>(
-      std::move(__f._M_func), forward<_Continuation>(__c));
+      std::move(__f._M_func), std::forward<_Continuation>(__c));
   }
 };
 

--- a/include/experimental/bits/copost.h
+++ b/include/experimental/bits/copost.h
@@ -23,7 +23,7 @@ struct __coinvoke_post
   template <class _E, class _F, class _A>
   void operator()(_E& __e, _F&& __f, const _A& __a)
   {
-    __e.post(forward<_F>(__f), __a);
+    __e.post(std::forward<_F>(__f), __a);
   }
 };
 
@@ -45,7 +45,7 @@ struct __coinvoke_post_ex
   template <class _E, class _F, class _A>
   void operator()(_E&, _F&& __f, const _A& __a)
   {
-    __e.post(forward<_F>(__f), __a);
+    __e.post(std::forward<_F>(__f), __a);
   }
 };
 

--- a/include/experimental/bits/exception_ptr_executor.h
+++ b/include/experimental/bits/exception_ptr_executor.h
@@ -66,19 +66,19 @@ struct __exception_ptr_executor
   template <class _F, class _A> void dispatch(_F&& __f, const _A& __a)
   {
     typedef typename decay<_F>::type _Func;
-    _M_executor.dispatch(__exception_ptr_call_wrapper<_Func>{_M_exception, forward<_F>(__f)}, __a);
+    _M_executor.dispatch(__exception_ptr_call_wrapper<_Func>{_M_exception, std::forward<_F>(__f)}, __a);
   }
 
   template <class _F, class _A> void post(_F&& __f, const _A& __a)
   {
     typedef typename decay<_F>::type _Func;
-    _M_executor.post(__exception_ptr_call_wrapper<_Func>{_M_exception, forward<_F>(__f)}, __a);
+    _M_executor.post(__exception_ptr_call_wrapper<_Func>{_M_exception, std::forward<_F>(__f)}, __a);
   }
 
   template <class _F, class _A> void defer(_F&& __f, const _A& __a)
   {
     typedef typename decay<_F>::type _Func;
-    _M_executor.defer(__exception_ptr_call_wrapper<_Func>{_M_exception, forward<_F>(__f)}, __a);
+    _M_executor.defer(__exception_ptr_call_wrapper<_Func>{_M_exception, std::forward<_F>(__f)}, __a);
   }
 
   friend bool operator==(const __exception_ptr_executor& __a, const __exception_ptr_executor& __b) noexcept

--- a/include/experimental/bits/execution_context.h
+++ b/include/experimental/bits/execution_context.h
@@ -207,7 +207,7 @@ template <class _Service, class... _Args> _Service&
 
   // Creation is performed without holding lock, to allow reentrancy.
   unique_ptr<execution_context::service> __new_s(
-    new _Service(__c, forward<_Args>(__args)...));
+    new _Service(__c, std::forward<_Args>(__args)...));
   __new_s->_M_id = __id;
 
   // Check if a duplicate was created while lock was not held.

--- a/include/experimental/bits/executor.h
+++ b/include/experimental/bits/executor.h
@@ -36,7 +36,7 @@ class __function
 {
 public:
   template <class _F> __function(_F&& __f, const _Alloc& __a)
-    : _M_func(forward<_F>(__f)), _M_alloc(__a)
+    : _M_func(std::forward<_F>(__f)), _M_alloc(__a)
   {
   }
 
@@ -427,7 +427,7 @@ template <class _Executor>
 inline executor& executor::operator=(_Executor __e)
 {
   __executor_impl_base* __tmp = _M_impl;
-  _M_impl = __executor_impl<typename decay<_Executor>::type>::_Create(forward<_Executor>(__e));
+  _M_impl = __executor_impl<typename decay<_Executor>::type>::_Create(std::forward<_Executor>(__e));
   __tmp->_Destroy();
   return *this;
 }
@@ -451,21 +451,21 @@ template <class _Func, class _Alloc>
 void executor::dispatch(_Func&& __f, const _Alloc& __a)
 {
   if (static_cast<void*>(_M_impl) == static_cast<void*>(__executor_impl<system_executor>::_Create()))
-    system_executor().dispatch(forward<_Func>(__f), __a);
+    system_executor().dispatch(std::forward<_Func>(__f), __a);
   else
-    _M_impl->_Dispatch(__function_ptr(forward<_Func>(__f), __a));
+    _M_impl->_Dispatch(__function_ptr(std::forward<_Func>(__f), __a));
 }
 
 template <class _Func, class _Alloc>
 inline void executor::post(_Func&& __f, const _Alloc& __a)
 {
-  _M_impl->_Post(__function_ptr(forward<_Func>(__f), __a));
+  _M_impl->_Post(__function_ptr(std::forward<_Func>(__f), __a));
 }
 
 template <class _Func, class _Alloc>
 inline void executor::defer(_Func&& __f, const _Alloc& __a)
 {
-  _M_impl->_Defer(__function_ptr(forward<_Func>(__f), __a));
+  _M_impl->_Defer(__function_ptr(std::forward<_Func>(__f), __a));
 }
 
 inline executor::operator bool() const noexcept

--- a/include/experimental/bits/executor_wrapper.h
+++ b/include/experimental/bits/executor_wrapper.h
@@ -50,21 +50,21 @@ inline executor_wrapper<_T, _Executor>::executor_wrapper(executor_arg_t,
 
 template <class _T, class _Executor> template <class _E, class _U>
 inline executor_wrapper<_T, _Executor>::executor_wrapper(int, _E&& __e, _U&& __u)
-  : executor_wrapper(forward<_E>(__e), forward<_U>(__u), uses_executor<_T, _Executor>())
+  : executor_wrapper(std::forward<_E>(__e), std::forward<_U>(__u), uses_executor<_T, _Executor>())
 {
 }
 
 template <class _T, class _Executor> template <class _E, class _U>
 inline executor_wrapper<_T, _Executor>::executor_wrapper(_E&& __e, _U&& __u, true_type)
-  : __executor_wrapper_base_executor<_Executor>(forward<_E>(__e)),
-    __executor_wrapper_base_wrapped<_T>(executor_arg, this->_M_executor, forward<_U>(__u))
+  : __executor_wrapper_base_executor<_Executor>(std::forward<_E>(__e)),
+    __executor_wrapper_base_wrapped<_T>(executor_arg, this->_M_executor, std::forward<_U>(__u))
 {
 }
 
 template <class _T, class _Executor> template <class _E, class _U>
 inline executor_wrapper<_T, _Executor>::executor_wrapper(_E&& __e, _U&& __u, false_type)
-  : __executor_wrapper_base_executor<_Executor>(forward<_E>(__e)),
-    __executor_wrapper_base_wrapped<_T>(forward<_U>(__u))
+  : __executor_wrapper_base_executor<_Executor>(std::forward<_E>(__e)),
+    __executor_wrapper_base_wrapped<_T>(std::forward<_U>(__u))
 {
 }
 
@@ -96,28 +96,28 @@ template <class _T, class _Executor> template <class... _Args>
 inline typename result_of<_T&(_Args&&...)>::type
 executor_wrapper<_T, _Executor>::operator()(_Args&&... __args) &
 {
-  return this->_M_wrapped(forward<_Args>(__args)...);
+  return this->_M_wrapped(std::forward<_Args>(__args)...);
 }
 
 template <class _T, class _Executor> template <class... _Args>
 inline typename result_of<const _T&(_Args&&...)>::type
 executor_wrapper<_T, _Executor>::operator()(_Args&&... __args) const &
 {
-  return this->_M_wrapped(forward<_Args>(__args)...);
+  return this->_M_wrapped(std::forward<_Args>(__args)...);
 }
 
 template <class _T, class _Executor> template <class... _Args>
 inline typename result_of<_T&&(_Args&&...)>::type
 executor_wrapper<_T, _Executor>::operator()(_Args&&... __args) &&
 {
-  return std::move(this->_M_wrapped)(forward<_Args>(__args)...);
+  return std::move(this->_M_wrapped)(std::forward<_Args>(__args)...);
 }
 
 template <class _T, class _Executor> template <class... _Args>
 inline typename result_of<const _T&&(_Args&&...)>::type
 executor_wrapper<_T, _Executor>::operator()(_Args&&... __args) const &&
 {
-  return std::move(this->_M_wrapped)(forward<_Args>(__args)...);
+  return std::move(this->_M_wrapped)(std::forward<_Args>(__args)...);
 }
 
 template <class _T, class _Executor, class _Signature>
@@ -179,7 +179,7 @@ struct continuation_of<executor_wrapper<_T, _Executor>(_Args...)>
   {
     return (wrap)(__f.get_executor(),
       _Wrapped_continuation_of::chain(std::move(__f.unwrap()),
-        forward<_C>(__c)));
+        std::forward<_C>(__c)));
   }
 };
 

--- a/include/experimental/bits/executor_wrapper_base.h
+++ b/include/experimental/bits/executor_wrapper_base.h
@@ -23,7 +23,7 @@ class __executor_wrapper_base_executor
 {
 protected:
   template <class... _Args> explicit __executor_wrapper_base_executor(_Args&&... __args)
-    : _M_executor(forward<_Args>(__args)...)
+    : _M_executor(std::forward<_Args>(__args)...)
   {
   }
 
@@ -35,7 +35,7 @@ class __executor_wrapper_base_wrapped
 {
 protected:
   template <class... _Args> explicit __executor_wrapper_base_wrapped(_Args&&... __args)
-    : _M_wrapped(forward<_Args>(__args)...)
+    : _M_wrapped(std::forward<_Args>(__args)...)
   {
   }
 

--- a/include/experimental/bits/function_traits.h
+++ b/include/experimental/bits/function_traits.h
@@ -232,25 +232,25 @@ class __chain<_Func, _FuncResult(_FuncArgs...), _Continuation>
 {
 public:
   template <class _F, class _C> __chain(_F&& __f, _C&& __c)
-    : _M_func(forward<_F>(__f)), _M_continuation(forward<_C>(__c))
+    : _M_func(std::forward<_F>(__f)), _M_continuation(std::forward<_C>(__c))
   {
   }
 
   void operator()(_FuncArgs... __args)
   {
-    this->_Invoke(is_same<void, _FuncResult>(), forward<_FuncArgs>(__args)...);
+    this->_Invoke(is_same<void, _FuncResult>(), std::forward<_FuncArgs>(__args)...);
   }
 
 private:
   void _Invoke(true_type, _FuncArgs... __args)
   {
-    std::move(_M_func)(forward<_FuncArgs>(__args)...);
+    std::move(_M_func)(std::forward<_FuncArgs>(__args)...);
     std::move(_M_continuation)();
   }
 
   void _Invoke(false_type, _FuncArgs... __args)
   {
-    std::move(_M_continuation)(std::move(_M_func)(forward<_FuncArgs>(__args)...));
+    std::move(_M_continuation)(std::move(_M_func)(std::forward<_FuncArgs>(__args)...));
   }
 
   _Func _M_func;

--- a/include/experimental/bits/invoker.h
+++ b/include/experimental/bits/invoker.h
@@ -46,7 +46,7 @@ public:
   {
     auto __ex(_M_work.get_executor());
     auto __alloc(associated_allocator<_Passive>::get(_M_passive));
-    __ex.dispatch(_Make_tuple_invoker(std::move(_M_passive), forward<_Args>(__args)...), __alloc);
+    __ex.dispatch(_Make_tuple_invoker(std::move(_M_passive), std::forward<_Args>(__args)...), __alloc);
   }
 
   _Passive& _Get_passive() noexcept
@@ -62,7 +62,7 @@ public:
   template <class _C> auto _Chain(_C&& __c)
   {
     return __active_invoker<_Result(_Args...), _CompletionTokens..., _C>(
-      _M_passive._Chain(forward<_C>(__c)), std::move(_M_work));
+      _M_passive._Chain(std::forward<_C>(__c)), std::move(_M_work));
   }
 
   template <class _R, class... _A, class... _T>
@@ -130,7 +130,7 @@ public:
 
   void operator()(_Args... __args)
   {
-    std::move(_M_handler)(forward<_Args>(__args)...);
+    std::move(_M_handler)(std::forward<_Args>(__args)...);
   }
 
   _Handler& _Get_handler() noexcept
@@ -217,7 +217,7 @@ public:
 
   void operator()(_Args... __args)
   {
-    continuation_of<_Handler(_Args...)>::chain(std::move(_M_handler), std::move(_M_tail))(forward<_Args>(__args)...);
+    continuation_of<_Handler(_Args...)>::chain(std::move(_M_handler), std::move(_M_tail))(std::forward<_Args>(__args)...);
   }
 
   const _Handler& _Get_handler() const noexcept
@@ -238,7 +238,7 @@ public:
   template <class _C> auto _Chain(_C&& __c)
   {
     return __passive_invoker<_Result(_Args...), _HeadToken, _TailTokens..., _C>(
-      std::move(_M_handler), _M_tail._Chain(forward<_C>(__c)));
+      std::move(_M_handler), _M_tail._Chain(std::forward<_C>(__c)));
   }
 
   template <class _R, class... _A, class... _T>
@@ -300,7 +300,7 @@ struct continuation_of<__active_invoker<_Result(_Args...), _CompletionTokens...>
   template <class _C>
   static auto chain(__active_invoker<_Result(_Args...), _CompletionTokens...>&& __f, _C&& __c)
   {
-    return __f._Chain(forward<_C>(__c));
+    return __f._Chain(std::forward<_C>(__c));
   }
 };
 

--- a/include/experimental/bits/loop_scheduler.h
+++ b/include/experimental/bits/loop_scheduler.h
@@ -122,19 +122,19 @@ inline void loop_scheduler::executor_type::on_work_finished() noexcept
 template <class _Func, class _Alloc>
 void loop_scheduler::executor_type::dispatch(_Func&& __f, const _Alloc& __a)
 {
-  _M_scheduler->_Dispatch(forward<_Func>(__f), __a);
+  _M_scheduler->_Dispatch(std::forward<_Func>(__f), __a);
 }
 
 template <class _Func, class _Alloc>
 void loop_scheduler::executor_type::post(_Func&& __f, const _Alloc& __a)
 {
-  _M_scheduler->_Post(forward<_Func>(__f), __a);
+  _M_scheduler->_Post(std::forward<_Func>(__f), __a);
 }
 
 template <class _Func, class _Alloc>
 void loop_scheduler::executor_type::defer(_Func&& __f, const _Alloc& __a)
 {
-  _M_scheduler->_Defer(forward<_Func>(__f), __a);
+  _M_scheduler->_Defer(std::forward<_Func>(__f), __a);
 }
 
 inline bool operator==(const loop_scheduler::executor_type& __a, const loop_scheduler::executor_type& __b) noexcept

--- a/include/experimental/bits/packaged_task.h
+++ b/include/experimental/bits/packaged_task.h
@@ -34,7 +34,7 @@ public:
 template <class _F, class _Alloc>
 inline packaged_token<typename decay<_F>::type, _Alloc> package(_F&& __f, const _Alloc& __a)
 {
-  return packaged_token<typename decay<_F>::type, _Alloc>(forward<_F>(__f), __a);
+  return packaged_token<typename decay<_F>::type, _Alloc>(std::forward<_F>(__f), __a);
 }
 
 template <class _R, class... _Args>

--- a/include/experimental/bits/promise_handler.h
+++ b/include/experimental/bits/promise_handler.h
@@ -31,7 +31,7 @@ struct __promise_invoker
 
   template <class _F>
   __promise_invoker(const shared_ptr<_Promise>& __p, _F&& __f)
-    : _M_promise(__p), _M_func(forward<_F>(__f)) {}
+    : _M_promise(__p), _M_func(std::forward<_F>(__f)) {}
 
   void operator()()
   {
@@ -67,21 +67,21 @@ struct __promise_executor
   template <class _F, class _A> void dispatch(_F&& __f, const _A&)
   {
     typedef typename decay<_F>::type _Func;
-    __promise_invoker<_Func, _Promise>(_M_promise, forward<_F>(__f))();
+    __promise_invoker<_Func, _Promise>(_M_promise, std::forward<_F>(__f))();
   }
 
   template <class _F, class _A> void post(_F&& __f, const _A& __a)
   {
     typedef typename decay<_F>::type _Func;
     system_executor().post(
-      __promise_invoker<_Func, _Promise>(_M_promise, forward<_F>(__f)), __a);
+      __promise_invoker<_Func, _Promise>(_M_promise, std::forward<_F>(__f)), __a);
   }
 
   template <class _F, class _A> void defer(_F&& __f, const _A& __a)
   {
     typedef typename decay<_F>::type _Func;
     system_executor().defer(
-      __promise_invoker<_Func, _Promise>(_M_promise, forward<_F>(__f)), __a);
+      __promise_invoker<_Func, _Promise>(_M_promise, std::forward<_F>(__f)), __a);
   }
 
   friend bool operator==(const __promise_executor& __a, const __promise_executor& __b) noexcept
@@ -105,7 +105,7 @@ struct __value_pack
 
   static void _Apply(promise<_Type>& __p, _Args... __args)
   {
-    __p.set_value(std::make_tuple(forward<_Args>(__args)...));
+    __p.set_value(std::make_tuple(std::forward<_Args>(__args)...));
   }
 };
 
@@ -116,7 +116,7 @@ struct __value_pack<_Arg>
 
   static void _Apply(promise<_Type>& __p, _Arg __arg)
   {
-    __p.set_value(forward<_Arg>(__arg));
+    __p.set_value(std::forward<_Arg>(__arg));
   }
 };
 
@@ -149,7 +149,7 @@ struct __promise_handler
 
   void operator()(_Args... __args)
   {
-    __value_pack<_Args...>::_Apply(*_M_promise, forward<_Args>(__args)...);
+    __value_pack<_Args...>::_Apply(*_M_promise, std::forward<_Args>(__args)...);
   }
 };
 
@@ -174,7 +174,7 @@ struct __promise_handler<error_code, _Args...>
     if (__e)
       _M_promise->set_exception(make_exception_ptr(system_error(__e)));
     else
-      __value_pack<_Args...>::_Apply(*_M_promise, forward<_Args>(__args)...);
+      __value_pack<_Args...>::_Apply(*_M_promise, std::forward<_Args>(__args)...);
   }
 };
 
@@ -199,7 +199,7 @@ struct __promise_handler<exception_ptr, _Args...>
     if (__e)
       _M_promise->set_exception(__e);
     else
-      __value_pack<_Args...>::_Apply(*_M_promise, forward<_Args>(__args)...);
+      __value_pack<_Args...>::_Apply(*_M_promise, std::forward<_Args>(__args)...);
   }
 };
 

--- a/include/experimental/bits/scheduler.h
+++ b/include/experimental/bits/scheduler.h
@@ -314,7 +314,7 @@ public:
   __scheduler_op& operator=(const __scheduler_op&) = delete;
 
   template <class _F> __scheduler_op(_F&& __f, const _Allocator& __a)
-    : _M_func(forward<_F>(__f)), _M_allocator(__a)
+    : _M_func(std::forward<_F>(__f)), _M_allocator(__a)
   {
   }
 
@@ -350,18 +350,18 @@ template <class _F, class _A> void __scheduler::_Dispatch(_F&& __f, const _A& __
   typedef typename decay<_F>::type _Func;
   if (_Call_stack::_Contains(this))
   {
-    _Func(forward<_F>(__f))();
+    _Func(std::forward<_F>(__f))();
   }
   else
   {
-    this->_Post(forward<_F>(__f), __a);
+    this->_Post(std::forward<_F>(__f), __a);
   }
 }
 
 template <class _F, class _A> void __scheduler::_Post(_F&& __f, const _A& __a)
 {
   typedef typename decay<_F>::type _Func;
-  auto __op(_Allocate_small_block<__scheduler_op<_Func, _A>>(__a, forward<_F>(__f), __a));
+  auto __op(_Allocate_small_block<__scheduler_op<_Func, _A>>(__a, std::forward<_F>(__f), __a));
 
   _Context* __ctx = _Call_stack::_Contains(this);
   if (__ctx == nullptr)
@@ -397,7 +397,7 @@ template <class _F, class _A> void __scheduler::_Post(_F&& __f, const _A& __a)
 template <class _F, class _A> void __scheduler::_Defer(_F&& __f, const _A& __a)
 {
   typedef typename decay<_F>::type _Func;
-  auto __op(_Allocate_small_block<__scheduler_op<_Func, _A>>(__a, forward<_F>(__f), __a));
+  auto __op(_Allocate_small_block<__scheduler_op<_Func, _A>>(__a, std::forward<_F>(__f), __a));
 
   _Context* __ctx = _Call_stack::_Contains(this);
   if (__ctx == nullptr)

--- a/include/experimental/bits/small_block_recycler.h
+++ b/include/experimental/bits/small_block_recycler.h
@@ -259,7 +259,7 @@ __small_block_ptr<_Allocator, _T> _Allocate_small_block(const _Allocator& __allo
   _T* __raw_p = __rebound_alloc.allocate(1);
   try
   {
-    _T* __p =  new (__raw_p) _T(forward<_Args>(__args)...);
+    _T* __p =  new (__raw_p) _T(std::forward<_Args>(__args)...);
     return __small_block_ptr<_Allocator, _T>(__p, __small_block_delete<_Allocator, _T>(__rebound_alloc));
   }
   catch (...)

--- a/include/experimental/bits/strand.h
+++ b/include/experimental/bits/strand.h
@@ -245,7 +245,7 @@ public:
   __strand_op& operator=(const __strand_op&) = delete;
 
   template <class _F> __strand_op(_F&& __f, const _Alloc& __a)
-    : _M_func(forward<_F>(__f)), _M_alloc(__a)
+    : _M_func(std::forward<_F>(__f)), _M_alloc(__a)
   {
   }
 
@@ -325,12 +325,12 @@ void strand<_Executor>::dispatch(_Func&& __f, const _Alloc& __a)
   typedef typename decay<_Func>::type _DecayFunc;
   if (__call_stack<__strand_impl>::_Contains(_M_impl.get()))
   {
-    _DecayFunc(forward<_Func>(__f))();
+    _DecayFunc(std::forward<_Func>(__f))();
     return;
   }
 
   typedef typename decay<_Func>::type _DecayFunc;
-  auto __op(_Allocate_small_block<__strand_op<_DecayFunc, _Alloc>>(__a, forward<_Func>(__f), __a));
+  auto __op(_Allocate_small_block<__strand_op<_DecayFunc, _Alloc>>(__a, std::forward<_Func>(__f), __a));
 
   {
     __strand_impl::_Lock_guard __lock(*_M_impl);
@@ -355,7 +355,7 @@ template <class _Executor> template <class _Func, class _Alloc>
 void strand<_Executor>::post(_Func&& __f, const _Alloc& __a)
 {
   typedef typename decay<_Func>::type _DecayFunc;
-  auto __op(_Allocate_small_block<__strand_op<_DecayFunc, _Alloc>>(__a, forward<_Func>(__f), __a));
+  auto __op(_Allocate_small_block<__strand_op<_DecayFunc, _Alloc>>(__a, std::forward<_Func>(__f), __a));
 
   {
     __strand_impl::_Lock_guard __lock(*_M_impl);
@@ -380,7 +380,7 @@ template <class _Executor> template <class _Func, class _Alloc>
 inline void strand<_Executor>::defer(_Func&& __f, const _Alloc& __a)
 {
   typedef typename decay<_Func>::type _DecayFunc;
-  auto __op(_Allocate_small_block<__strand_op<_DecayFunc, _Alloc>>(__a, forward<_Func>(__f), __a));
+  auto __op(_Allocate_small_block<__strand_op<_DecayFunc, _Alloc>>(__a, std::forward<_Func>(__f), __a));
 
   {
     __strand_impl::_Lock_guard __lock(*_M_impl);
@@ -415,7 +415,7 @@ inline bool operator!=(const strand<_Executor>& __a, const strand<_Executor>& __
 
 template <class _T> inline auto make_strand(_T&& __t)
 {
-  return strand<typename decay<_T>::type>(forward<_T>(__t));
+  return strand<typename decay<_T>::type>(std::forward<_T>(__t));
 }
 
 } // inline namespace concurrency_v1

--- a/include/experimental/bits/system_executor.h
+++ b/include/experimental/bits/system_executor.h
@@ -71,12 +71,12 @@ public:
 
   template <class _F, class _A> void _Post(_F&& __f, const _A& __a)
   {
-    _M_scheduler._Post(forward<_F>(__f), __a);
+    _M_scheduler._Post(std::forward<_F>(__f), __a);
   }
 
   template <class _F, class _A> void _Defer(_F&& __f, const _A& __a)
   {
-    _M_scheduler._Defer(forward<_F>(__f), __a);
+    _M_scheduler._Defer(std::forward<_F>(__f), __a);
   }
 
 private:
@@ -105,20 +105,20 @@ inline void system_executor::on_work_finished() noexcept
 template <class _Func, class _Alloc>
 void system_executor::dispatch(_Func&& __f, const _Alloc&)
 {
-  typename decay<_Func>::type tmp(forward<_Func>(__f));
+  typename decay<_Func>::type tmp(std::forward<_Func>(__f));
   std::move(tmp)();
 }
 
 template <class _Func, class _Alloc>
 inline void system_executor::post(_Func&& __f, const _Alloc& __a)
 {
-  __system_executor_impl::_Instance()._Post(forward<_Func>(__f), __a);
+  __system_executor_impl::_Instance()._Post(std::forward<_Func>(__f), __a);
 }
 
 template <class _Func, class _Alloc>
 inline void system_executor::defer(_Func&& __f, const _Alloc& __a)
 {
-  __system_executor_impl::_Instance()._Defer(forward<_Func>(__f), __a);
+  __system_executor_impl::_Instance()._Defer(std::forward<_Func>(__f), __a);
 }
 
 inline bool operator==(const system_executor&, const system_executor&) noexcept

--- a/include/experimental/bits/thread_pool.h
+++ b/include/experimental/bits/thread_pool.h
@@ -84,19 +84,19 @@ inline void thread_pool::executor_type::on_work_finished() noexcept
 template <class _Func, class _Alloc>
 void thread_pool::executor_type::dispatch(_Func&& __f, const _Alloc& __a)
 {
-  _M_pool->_Dispatch(forward<_Func>(__f), __a);
+  _M_pool->_Dispatch(std::forward<_Func>(__f), __a);
 }
 
 template <class _Func, class _Alloc>
 void thread_pool::executor_type::post(_Func&& __f, const _Alloc& __a)
 {
-  _M_pool->_Post(forward<_Func>(__f), __a);
+  _M_pool->_Post(std::forward<_Func>(__f), __a);
 }
 
 template <class _Func, class _Alloc>
 void thread_pool::executor_type::defer(_Func&& __f, const _Alloc& __a)
 {
-  _M_pool->_Defer(forward<_Func>(__f), __a);
+  _M_pool->_Defer(std::forward<_Func>(__f), __a);
 }
 
 inline bool operator==(const thread_pool::executor_type& __a, const thread_pool::executor_type& __b) noexcept

--- a/include/experimental/bits/tuple_utils.h
+++ b/include/experimental/bits/tuple_utils.h
@@ -41,42 +41,42 @@ template <class _Func, size_t... _I, class... _Values, class... _Args>
 inline auto _Tuple_invoke_impl(_Func&& __f, _Index_sequence<_I...>,
   tuple<_Values...>& __values, _Args&&... __args)
 {
-  return forward<_Func>(__f)(get<_I>(__values)..., forward<_Args>(__args)...);
+  return std::forward<_Func>(__f)(get<_I>(__values)..., std::forward<_Args>(__args)...);
 }
 
 template <class _Func, size_t... _I, class... _Values, class... _Args>
 inline auto _Tuple_invoke_impl(_Func&& __f, _Index_sequence<_I...>,
   tuple<_Values...>&& __values, _Args&&... __args)
 {
-  return forward<_Func>(__f)(std::move(get<_I>(__values))..., forward<_Args>(__args)...);
+  return std::forward<_Func>(__f)(std::move(get<_I>(__values))..., std::forward<_Args>(__args)...);
 }
 
 template <class _Func, class... _Values, class... _Args>
 inline auto _Tuple_invoke(_Func&& __f, tuple<_Values...>& __values, _Args&&... __args)
 {
-  return _Tuple_invoke_impl(forward<_Func>(__f),
+  return _Tuple_invoke_impl(std::forward<_Func>(__f),
     typename _Make_index_sequence<sizeof...(_Values)>::_Type(),
-      __values, forward<_Args>(__args)...);
+      __values, std::forward<_Args>(__args)...);
 }
 
 template <class _Func, class... _Values, class... _Args>
 inline auto _Tuple_invoke(_Func&& __f, tuple<_Values...>&& __values, _Args&&... __args)
 {
-  return _Tuple_invoke_impl(forward<_Func>(__f),
+  return _Tuple_invoke_impl(std::forward<_Func>(__f),
     typename _Make_index_sequence<sizeof...(_Values)>::_Type(),
-      std::move(__values), forward<_Args>(__args)...);
+      std::move(__values), std::forward<_Args>(__args)...);
 }
 
 template <class _Func, class... _Args>
 inline auto _Tuple_invoke(_Func&& __f, tuple<>&, _Args&&... __args)
 {
-  return forward<_Func>(__f)(forward<_Args>(__args)...);
+  return std::forward<_Func>(__f)(std::forward<_Args>(__args)...);
 }
 
 template <class _Func, class... _Args>
 inline auto _Tuple_invoke(_Func&& __f, tuple<>&&, _Args&&... __args)
 {
-  return forward<_Func>(__f)(forward<_Args>(__args)...);
+  return std::forward<_Func>(__f)(std::forward<_Args>(__args)...);
 }
 
 // _Make_tuple_invoker: Creates a function object to call a function using
@@ -98,14 +98,14 @@ template <class _Handler, class... _Values>
 inline auto _Make_tuple_invoker(_Handler&& __h, tuple<_Values...>&& __t)
 {
   return __tuple_invoker<typename decay<_Handler>::type, _Values...>{
-    forward<_Handler>(__h), std::move(__t)};
+    std::forward<_Handler>(__h), std::move(__t)};
 }
 
 template <class _Handler, class... _Values>
 inline auto _Make_tuple_invoker(_Handler&& __h, _Values&&... __v)
 {
   return __tuple_invoker<typename decay<_Handler>::type, typename decay<_Values>::type...>{
-    forward<_Handler>(__h), std::make_tuple(forward<_Values>(__v)...)};
+    std::forward<_Handler>(__h), std::make_tuple(std::forward<_Values>(__v)...)};
 }
 
 // __args_tuple: Determines tuple type corresponding to a signature's argument list.

--- a/include/experimental/bits/wait_op.h
+++ b/include/experimental/bits/wait_op.h
@@ -36,7 +36,7 @@ class __wait_op
 {
 public:
   template <class _F> explicit __wait_op(_F&& __f)
-    : _M_func(forward<_F>(__f)), _M_work(get_associated_executor(_M_func))
+    : _M_func(std::forward<_F>(__f)), _M_work(get_associated_executor(_M_func))
   {
   }
 

--- a/include/experimental/bits/wrap.h
+++ b/include/experimental/bits/wrap.h
@@ -51,7 +51,7 @@ template <class _Executor, class _T>
 inline typename __wrap_with_executor<_Executor, _T>::_Result
   wrap(const _Executor& __e, _T&& __t)
 {
-  return executor_wrapper<typename decay<_T>::type, _Executor>(forward<_T>(__t), __e);
+  return executor_wrapper<typename decay<_T>::type, _Executor>(std::forward<_T>(__t), __e);
 }
 
 template <class _ExecutionContext, class _T>
@@ -59,7 +59,7 @@ inline typename __wrap_with_execution_context<_ExecutionContext, _T>::_Result
   wrap(_ExecutionContext& __c, _T&& __t)
 {
   return executor_wrapper<typename decay<_T>::type,
-    typename _ExecutionContext::executor_type>(forward<_T>(__t), __c.get_executor());
+    typename _ExecutionContext::executor_type>(std::forward<_T>(__t), __c.get_executor());
 }
 
 } // inline namespace concurrency_v1

--- a/include/experimental/bits/yield_context.h
+++ b/include/experimental/bits/yield_context.h
@@ -101,7 +101,7 @@ struct __yield_context_result
   template <class... _Args>
   void _Set_value(_Args&&... __args)
   {
-    _M_value = std::make_tuple(forward<_Args>(__args)...);
+    _M_value = std::make_tuple(std::forward<_Args>(__args)...);
   }
 
   decltype(_Tuple_get(declval<tuple<_Values...>>())) _Get()
@@ -131,7 +131,7 @@ struct __yield_context_handler
 
   template <class... _Args> void operator()(_Args&&... __args)
   {
-    _M_result->_Set_value(forward<_Args>(__args)...);
+    _M_result->_Set_value(std::forward<_Args>(__args)...);
     if (_M_result->_M_ready.test_and_set())
     {
       typename __yield_context_callee::_Lock_guard __lock(*_M_callee);
@@ -168,7 +168,7 @@ struct __yield_context_handler<_Executor, error_code, _Values...>
       *_M_error_code = __e;
     else if (__e)
       _M_result->_M_exception = make_exception_ptr(system_error(__e));
-    _M_result->_Set_value(forward<_Args>(__args)...);
+    _M_result->_Set_value(std::forward<_Args>(__args)...);
     if (_M_result->_M_ready.test_and_set())
     {
       typename __yield_context_callee::_Lock_guard __lock(*_M_callee);
@@ -203,7 +203,7 @@ struct __yield_context_handler<_Executor, exception_ptr, _Values...>
   template <class... _Args> void operator()(const exception_ptr& __e, _Args&&... __args)
   {
     _M_result->_M_exception = __e;
-    _M_result->_Set_value(forward<_Args>(__args)...);
+    _M_result->_Set_value(std::forward<_Args>(__args)...);
     if (_M_result->_M_ready.test_and_set())
     {
       typename __yield_context_callee::_Lock_guard __lock(*_M_callee);
@@ -318,19 +318,19 @@ struct __yield_context_launcher
   executor_work<_Executor> _M_work;
 
   template <class _F> __yield_context_launcher(_F&& __f)
-    : _M_func(forward<_F>(__f)), _M_work(associated_executor<_Func>::get(_M_func))
+    : _M_func(std::forward<_F>(__f)), _M_work(associated_executor<_Func>::get(_M_func))
   {
   }
 
   template <class _F> __yield_context_launcher(
     executor_arg_t, const _Executor& __e, _F&& __f)
-      : _M_func(forward<_F>(__f)), _M_work(__e)
+      : _M_func(std::forward<_F>(__f)), _M_work(__e)
   {
   }
 
   template <class _F, class _C> __yield_context_launcher(
     true_type, const executor_work<_Executor>& __w, _F&& __f, _C&& __c)
-      : _M_func(forward<_F>(__f)), _M_continuation(forward<_C>(__c)), _M_work(__w)
+      : _M_func(std::forward<_F>(__f)), _M_continuation(std::forward<_C>(__c)), _M_work(__w)
   {
   }
 
@@ -345,7 +345,7 @@ struct __yield_context_launcher
 
     __yield_context_entry_point<_Executor, _Func, _Continuation, typename decay<_Args>::type...>
       __ep{std::move(_M_func), std::move(_M_continuation),
-        std::tie(forward<_Args>(__args)...), std::move(_M_work), __callee};
+        std::tie(std::forward<_Args>(__args)...), std::move(_M_work), __callee};
 
 #ifdef EXECUTORS_NO_BOOST
     assert(0 && "boost required to make use of yield_context");
@@ -393,7 +393,7 @@ struct continuation_of<__yield_context_launcher<_Executor, _Func>(_Args...)>
   {
     return __yield_context_launcher<_Executor, _Func,
       typename decay<_Continuation>::type>(true_type(), std::move(__f._M_work),
-        std::move(__f._M_func), forward<_Continuation>(__c));
+        std::move(__f._M_func), std::forward<_Continuation>(__c));
   }
 };
 

--- a/include/experimental/type_traits
+++ b/include/experimental/type_traits
@@ -173,8 +173,8 @@ struct continuation_of<_Func(_Args...)>
   >::type::signature signature;
 
   // If _Func and decay<_Func>::type are different types, returns
-  // continuation_of<typename decay<_Func>::type>::chain(forward<_F>(__f),
-  // forward<_Continuation>(__c)). Otherwise, returns a function object that,
+  // continuation_of<typename decay<_Func>::type>::chain(std::forward<_F>(__f),
+  // std::forward<_Continuation>(__c)). Otherwise, returns a function object that,
   // when invoked, calls a copy of __f, and then passes the result to a copy of
   // __c.
   template <class _F, class _Continuation>
@@ -182,7 +182,7 @@ struct continuation_of<_Func(_Args...)>
   {
     return continuation_of::_Chain(
       is_same<_Func, typename decay<_Func>::type>(),
-        forward<_F>(__f), forward<_Continuation>(__c));
+        std::forward<_F>(__f), std::forward<_Continuation>(__c));
   }
 
 private:
@@ -191,14 +191,14 @@ private:
   {
     return __chain<_Func, __signature_t<_Func>,
       typename decay<_Continuation>::type>(
-        forward<_F>(__f), forward<_Continuation>(__c));
+        std::forward<_F>(__f), std::forward<_Continuation>(__c));
   }
 
   template <class _F, class _Continuation>
   static auto _Chain(false_type, _F&& __f, _Continuation&& __c)
   {
     return continuation_of<typename decay<_Func>::type>::chain(
-      forward<_F>(__f), forward<_Continuation>(__c));
+      std::forward<_F>(__f), std::forward<_Continuation>(__c));
   }
 };
 


### PR DESCRIPTION
Is it the intent that the calls to forward<T> are unqualified? I ran into an issue where boost::forward (as part of the boost.move library was being found through ADL for boost types (specifically boost::shared_ptr).

I fixed it by fully qualifying all of the calls to forward, but I'm not sure if that's the correct change or not.
